### PR TITLE
doc: adding example with compiling code for easier use for new users of skewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ func main() {
 	client := compute.NewResourceSkusClient(sub)
 	client.Authorizer = authorizer
 
-	// or instantiate a cache for this package!
 	cache, err := skewer.NewCache(context.Background(), skewer.WithLocation("southcentralus"), skewer.WithResourceClient(client))
 	if err != nil {
 		fmt.Printf("failed to instantiate sku cache: %s", err)


### PR DESCRIPTION
** Why was this PR Needed?** 
The introductory example did a good job of showing off some new methods, but requires the user to have some baseline understanding of what variables to set to get the project up and running, and the azure new credential from environment hides some of this behind some abscraction. 


So i opted into putting the variables there, and having the main.go script runnable so the users can get a compiled example from the get go to start experimenting with the package