### PR TITLE
add IncludesFilter FilterFn

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -371,5 +371,12 @@ func UnsafeLocationFilter(location string) func(*SKU) bool {
 	}
 }
 
+// IncludesFilter returns a FilterFn that checks if the SKU is included in the provided list of SKUs.
+func IncludesFilter(skuList []SKU) func(*SKU) bool {
+	return func(s *SKU) bool {
+		return s.Includes(skuList)
+	}
+}
+
 // MapFn is a convenience type for mapping.
 type MapFn func(*SKU) SKU

--- a/cache.go
+++ b/cache.go
@@ -374,7 +374,7 @@ func UnsafeLocationFilter(location string) func(*SKU) bool {
 // IncludesFilter returns a FilterFn that checks if the SKU is included in the provided list of SKUs.
 func IncludesFilter(skuList []SKU) func(*SKU) bool {
 	return func(s *SKU) bool {
-		return s.Includes(skuList)
+		return s.MemberOf(skuList)
 	}
 }
 

--- a/sku.go
+++ b/sku.go
@@ -573,8 +573,8 @@ func (s *SKU) Equal(other *SKU) bool {
 		otherErr != nil
 }
 
-// Includes returns true if the SKU's name is in the list of SKUs.
-func (s *SKU) Includes(skuList []SKU) bool {
+// MemberOf returns true if the SKU's name is in the list of SKUs.
+func (s *SKU) MemberOf(skuList []SKU) bool {
 	for _, sku := range skuList {
 		if s.GetName() == sku.GetName() {
 			return true

--- a/sku.go
+++ b/sku.go
@@ -572,3 +572,13 @@ func (s *SKU) Equal(other *SKU) bool {
 		localErr != nil &&
 		otherErr != nil
 }
+
+// Includes returns true if the SKU's name is in the list of SKUs.
+func (s *SKU) Includes(skuList []SKU) bool {
+	for _, sku := range skuList {
+		if s.GetName() == sku.GetName() {
+			return true
+		}
+	}
+	return false
+}

--- a/sku_test.go
+++ b/sku_test.go
@@ -518,7 +518,7 @@ func Test_SKU_HasCapabilityInZone(t *testing.T) {
 	}
 }
 
-// Test_SKU_Includes tests the SKU Includes method
+// Test_SKU_MemberOf tests the SKU MemberOf method
 func Test_SKU_Includes(t *testing.T) {
 	cases := map[string]struct {
 		skuList []SKU
@@ -562,7 +562,7 @@ func Test_SKU_Includes(t *testing.T) {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
 			sku := SKU(tc.sku)
-			if diff := cmp.Diff(tc.expect, sku.Includes(tc.skuList)); diff != "" {
+			if diff := cmp.Diff(tc.expect, sku.MemberOf(tc.skuList)); diff != "" {
 				t.Error(diff)
 			}
 		})

--- a/sku_test.go
+++ b/sku_test.go
@@ -517,3 +517,54 @@ func Test_SKU_HasCapabilityInZone(t *testing.T) {
 		})
 	}
 }
+
+// Test_SKU_Includes tests the SKU Includes method
+func Test_SKU_Includes(t *testing.T) {
+	cases := map[string]struct {
+		skuList []SKU
+		sku     SKU
+		expect  bool
+	}{
+		"empty list should not include": {
+			skuList: []SKU{},
+			sku: SKU{
+				Name: to.StringPtr("foo"),
+			},
+			expect: false,
+		},
+		"missing name should not include": {
+			skuList: []SKU{
+				{
+					Name: to.StringPtr("foo"),
+				},
+			},
+			sku: SKU{
+				Name: to.StringPtr("bar"),
+			},
+			expect: false,
+		},
+		"name is included": {
+			skuList: []SKU{
+				{
+					Name: to.StringPtr("foo"),
+				},
+				{
+					Name: to.StringPtr("bar"),
+				},
+			},
+			sku: SKU{
+				Name: to.StringPtr("bar"),
+			},
+			expect: true,
+		},
+	}
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			sku := SKU(tc.sku)
+			if diff := cmp.Diff(tc.expect, sku.Includes(tc.skuList)); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds an `Includes()` filter to the built-in `SKU` type (thin wrapper around Azure's SDK track 1 `compute.ResourceSku` type).

This is an expensive filter as it may have to enumerate through an entire list (unbound in size) of SKUs. Only intended for use in cache-enabled data stores.

We also expose a `IncludesFilter` FilterFn so that karpenter-provider-azure can call it conveniently from the cache List flow.