### PR TITLE
feat: nvme disk size added

### DIFF
--- a/const.go
+++ b/const.go
@@ -35,6 +35,8 @@ const (
 	// UltraSSDAvailable identifies the capability for ultra ssd
 	// enablement.
 	UltraSSDAvailable = "UltraSSDAvailable"
+	// NvmeDiskSizeInMiB declares the disk size of the Nvme drive
+	NvmeDiskSizeInMiB = "NvmeDiskSizeInMiB"
 	// CachedDiskBytes identifies the maximum size of the cache disk for
 	// a vm.
 	CachedDiskBytes = "CachedDiskBytes"

--- a/sku.go
+++ b/sku.go
@@ -59,6 +59,11 @@ func (s *SKU) Memory() (float64, error) {
 	return s.GetCapabilityFloatQuantity(MemoryGB)
 }
 
+// NvmeDiskSizeInMiB returns the integer value for the disk size
+func (s *SKU) NvmeDiskSizeInMiB() (int64, error) {
+	return s.GetCapabilityIntegerQuantity(NvmeDiskSizeInMiB)
+}
+
 // MaxCachedDiskBytes returns the number of bytes available for the
 // cache if it exists on this VM size.
 func (s *SKU) MaxCachedDiskBytes() (int64, error) {


### PR DESCRIPTION
V6 Skus added support for a new type of ephemeral os disk. 


```
{Name: lo.ToPtr("NvmeDiskSizeInMiB"), Value: lo.ToPtr("7208960")},
{Name: lo.ToPtr("NvmeSizePerDiskInMiB"), Value: lo.ToPtr("1802240")},
```
The value for NvmeDiskSizeInMiB needs to be updated and queriable. 

This pr does just that, adds the ability to query that capability. 