### PR TITLE
refactor: make GetVMSize function public

### DIFF
--- a/sku.go
+++ b/sku.go
@@ -430,7 +430,7 @@ func (s *SKU) GetSize() string {
 }
 
 func (s *SKU) GetVMSize() (*VMSizeType, error) {
-	return getVMSize(s.GetSize())
+	return GetVMSize(s.GetSize())
 }
 
 // GetLocation returns the location for a given SKU.

--- a/vmsize.go
+++ b/vmsize.go
@@ -55,8 +55,8 @@ func parseVMSize(vmSizeName string) ([]string, error) {
 	return parts, nil
 }
 
-// getVMSize is a helper function used by GetVMSize() in sku.go
-func getVMSize(vmSizeName string) (*VMSizeType, error) {
+// GetVMSize is a helper function used by GetVMSize() in sku.go
+func GetVMSize(vmSizeName string) (*VMSizeType, error) {
 	vmSize := VMSizeType{}
 
 	parts, err := parseVMSize(vmSizeName)

--- a/vmsize_test.go
+++ b/vmsize_test.go
@@ -177,11 +177,11 @@ var testCases = []struct {
 	},
 }
 
-// Test_getSize tests the getSize() function.
-func Test_getVMsize(t *testing.T) {
+// Test_GetVMSize tests the GetVMSize() function.
+func Test_GetVMSize(t *testing.T) {
 	a := assert.New(t)
 	for _, test := range testCases {
-		vmSize, err := getVMSize(test.size)
+		vmSize, err := GetVMSize(test.size)
 		a.Equal(test.err, err)
 		if err != nil {
 			continue


### PR DESCRIPTION
This PR refactors the VM size parsing functionality by making the `GetVMSize` function public, allowing external consumers to directly parse Azure VM size strings into structured `VMSizeType` objects.
